### PR TITLE
🐛 fix: update base URL for deployment path

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   },
 
   url: "https://imfsiddiqui.github.io",
-  baseUrl: "/",
+  baseUrl: "/wonders/",
 
   favicon: favicon,
   title: title,


### PR DESCRIPTION
## 🎯 Purpose

Change the base URL in the configuration from "/" to "/wonders/" to ensure correct deployment path.

## 💡 Notes

No breaking changes introduced.